### PR TITLE
[Hybrid_Endpoint] Improve error reporting

### DIFF
--- a/hybridauth/Hybrid/Endpoint.php
+++ b/hybridauth/Hybrid/Endpoint.php
@@ -209,7 +209,7 @@ class Hybrid_Endpoint {
 			catch ( Exception $e ){
 				Hybrid_Logger::error( "Endpoint: Error while trying to init Hybrid_Auth: " . $e->getMessage()); 
 
-				throw new Hybrid_Exception( "Oophs. Error!" );
+				throw new Hybrid_Exception( "Endpoint: Error while trying to init Hybrid_Auth: " . $e->getMessage(), $e->getCode(), $e);
 			}
 		}
 	}


### PR DESCRIPTION
This patch improves error reporting within Hybrid_Endpoint authInit() function.

With this patch exception messages like this 

> Hybrid auth endpoint process failed: Oophs. Error!

in log files will be more meaningful.
